### PR TITLE
Removed deprecated prop-changes paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,6 @@ handleClick = () => {
 ...
 ```
 
-## State changes vs. prop changes
-![Not the same thing!](http://4.bp.blogspot.com/-YpCHzw3WdTo/UzNBI3BzYKI/AAAAAAAAJoY/S34pUkXKhUU/s1600/aaa.png)
-
-It's important to note the difference between changes in state and changes in props. Changes in state and/or props will both trigger a re-render of our React component. However, changes in state can only happen _internally_ due to components changing their own state. Changes in props can only happen _externally_, due to changes in prop values being passed in.
-
 ## Resources
 - [Transferring props](https://facebook.github.io/react/docs/transferring-props.html)
 - [Component API](https://facebook.github.io/react/docs/component-api.html)


### PR DESCRIPTION
Props are read-only and cannot be modified. Maybe reword the paragraph to clarify that passing props from parent to child does not modify existing properties-- it creates and renders a new instance of the child component with different properties than the previously rendered instance. 